### PR TITLE
[FIX] 부품 재고 확인 응답 DTO 수정

### DIFF
--- a/src/main/java/com/stockmate/order/api/order/dto/InventoryCheckApiResponse.java
+++ b/src/main/java/com/stockmate/order/api/order/dto/InventoryCheckApiResponse.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -13,5 +15,6 @@ public class InventoryCheckApiResponse {
     private int status;
     private boolean success;
     private String message;
-    private InventoryCheckResponseDTO data;
+    private List<InventoryCheckItemResponseDTO> data;
+    private int totalAmount;
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #12

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 부품 재고 확인 응답 DTO 수정하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 재고 확인 응답이 단일 항목에서 다중 항목 리스트로 확장되어 한 번의 요청으로 여러 품목의 점검 결과를 확인할 수 있습니다.
  * 총합을 나타내는 totalAmount 필드가 추가되어 전체 결과의 합계를 함께 제공합니다.
  * 오류 발생 시 응답 구조가 정돈되어 어떤 품목에서 판매 불가가 발생했는지 명확히 전달됩니다.
  * 성공 응답에서도 리스트 기반 결과와 총합이 함께 반환되어 클라이언트 표시와 집계가 용이합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->