### PR TITLE
[FEAT] 주문 취소 기능 구현

### DIFF
--- a/src/main/java/com/stockmate/order/api/order/controller/OrderController.java
+++ b/src/main/java/com/stockmate/order/api/order/controller/OrderController.java
@@ -25,12 +25,32 @@ public class OrderController {
     @Operation(summary = "주문 생성 API", description = "본사에 있는 부품들을 발주합니다.")
     @PostMapping
     public ResponseEntity<ApiResponse<Void>> makeOrder(@RequestBody OrderRequestDTO orderRequestDTO, @AuthenticationPrincipal SecurityUser securityUser) {
-        log.info("부품 발주 요청 - 요청 가맹점 ID: {}, 주문 항목 수: {}", 
-                securityUser.getMemberId(), orderRequestDTO.getOrderItems().size());
+        log.info("부품 발주 요청 - 요청 가맹점 ID: {}, 주문 항목 수: {}", securityUser.getMemberId(), orderRequestDTO.getOrderItems().size());
 
         orderService.makeOrder(orderRequestDTO, securityUser.getMemberId());
         return ApiResponse.success_only(SuccessStatus.SEND_PARTS_ORDER_SUCCESS);
     }
 
+    @Operation(summary = "주문 취소 API", description = "생성한 주문을 취소합니다. (본인 주문 또는 ADMIN/SUPER_ADMIN)")
+    @PutMapping("/{orderId}/cancel")
+    public ResponseEntity<ApiResponse<Void>> cancelOrder(@PathVariable Long orderId, @AuthenticationPrincipal SecurityUser securityUser) {
+        
+        log.info("주문 취소 요청 - 요청 가맹점 ID: {}, 취소 주문 ID: {}, Role: {}", securityUser.getMemberId(), orderId, securityUser.getRole());
+        orderService.cancelOrder(orderId, securityUser.getMemberId(), securityUser.getRole());
+        
+        log.info("주문 취소 완료 - Order ID: {}", orderId);
+        return ApiResponse.success_only(SuccessStatus.SEND_CANCELLED_ORDER_SUCCESS);
+    }
+
+    @Operation(summary = "주문 물리적 삭제 API", description = "주문을 DB에서 완전히 삭제합니다. (ADMIN/SUPER_ADMIN만 가능)")
+    @DeleteMapping("/{orderId}")
+    public ResponseEntity<ApiResponse<Void>> deleteOrder(@PathVariable Long orderId, @AuthenticationPrincipal SecurityUser securityUser) {
+        
+        log.info("주문 물리적 삭제 요청 - Order ID: {}, 요청자 ID : {}, 요청자 Role: {}", orderId, securityUser.getMemberId(), securityUser.getRole());
+        orderService.deleteOrder(orderId, securityUser);
+        
+        log.info("주문 물리적 삭제 완료 - Order ID: {}", orderId);
+        return ApiResponse.success_only(SuccessStatus.DELETE_ORDER_SUCCESS);
+    }
 
 }

--- a/src/main/java/com/stockmate/order/api/order/entity/Order.java
+++ b/src/main/java/com/stockmate/order/api/order/entity/Order.java
@@ -53,4 +53,9 @@ public class Order extends BaseTimeEntity {
         }
     }
 
+    // 주문 취소
+    public void cancel() {
+        this.orderStatus = OrderStatus.CANCELLED;
+    }
+
 }

--- a/src/main/java/com/stockmate/order/api/order/entity/OrderStatus.java
+++ b/src/main/java/com/stockmate/order/api/order/entity/OrderStatus.java
@@ -12,7 +12,8 @@ public enum OrderStatus {
     SHIPPING("SHIPPING"), // 배송중
     REJECTED("REJECTED"), // 출고 반려
     DELIVERED("DELIVERED"), // 배송 완료
-    RECEIVED("RECEIVED"); // 입고 완료
+    RECEIVED("RECEIVED"), // 입고 완료
+    CANCELLED("CANCELLED"); // 주문 취소
 
     private final String key;
 }

--- a/src/main/java/com/stockmate/order/api/order/service/OrderService.java
+++ b/src/main/java/com/stockmate/order/api/order/service/OrderService.java
@@ -5,6 +5,11 @@ import com.stockmate.order.api.order.entity.Order;
 import com.stockmate.order.api.order.entity.OrderItem;
 import com.stockmate.order.api.order.entity.OrderStatus;
 import com.stockmate.order.api.order.repository.OrderRepository;
+import com.stockmate.order.common.config.security.Role;
+import com.stockmate.order.common.config.security.SecurityUser;
+import com.stockmate.order.common.exception.BadRequestException;
+import com.stockmate.order.common.exception.NotFoundException;
+import com.stockmate.order.common.response.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -79,5 +84,71 @@ public class OrderService {
 
         // TODO: 추후 결제 서버에 totalPrice 전송
         // paymentService.processPayment(checkResult.getTotalPrice(), savedOrder.getOrderId());
+    }
+
+    // 주문 취소
+    @Transactional
+    public void cancelOrder(Long orderId, Long memberId, Role role) {
+        log.info("주문 취소 요청 - Order ID: {}, Member ID: {}, Role: {}", orderId, memberId, role);
+
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> {
+                    log.error("주문을 찾을 수 없음 - Order ID: {}", orderId);
+                    return new NotFoundException(ErrorStatus.ORDER_NOT_FOUND_EXCEPTION.getMessage());
+                });
+
+        // 주문자 확인 (ADMIN, SUPER_ADMIN은 모든 주문 취소 가능)
+        boolean isAdmin = role == Role.ADMIN || role == Role.SUPER_ADMIN;
+        if (!isAdmin && !order.getMemberId().equals(memberId)) {
+            log.error("권한 없음 - Order의 Member ID: {}, 요청자 Member ID: {}, Role: {}", 
+                    order.getMemberId(), memberId, role);
+            throw new BadRequestException(ErrorStatus.INVALID_ROLE_EXCEPTION.getMessage());
+        }
+
+        // 이미 취소된 주문인지 확인
+        if (order.getOrderStatus() == OrderStatus.CANCELLED) {
+            log.warn("이미 취소된 주문 - Order ID: {}", orderId);
+            throw new BadRequestException(ErrorStatus.ALREADY_CANCELLED_ORDER_EXCEPTION.getMessage());
+        }
+
+        // 배송 중이거나 완료된 주문은 취소 불가 (ADMIN, SUPER_ADMIN은 가능)
+        if (!isAdmin && (order.getOrderStatus() == OrderStatus.SHIPPING || 
+            order.getOrderStatus() == OrderStatus.DELIVERED ||
+            order.getOrderStatus() == OrderStatus.RECEIVED)) {
+            log.warn("취소 불가능한 상태 - Order ID: {}, Status: {}", orderId, order.getOrderStatus());
+            throw new BadRequestException(ErrorStatus.ALREADY_SHIPPED_OR_DELIVERED_ORDER_EXCEPTION.getMessage());
+        }
+
+        order.cancel();
+        orderRepository.save(order);
+
+        log.info("주문 취소 완료 - Order ID: {}, Order Number: {}, 취소자 Role: {}", 
+                orderId, order.getOrderNumber(), role);
+    }
+
+    // 주문 물리적 삭제 (테스트용 - ADMIN, SUPER_ADMIN만 가능)
+    @Transactional
+    public void deleteOrder(Long orderId, SecurityUser securityUser) {
+        Role role = securityUser.getRole();
+        Long adminId = securityUser.getMemberId();
+
+        log.info("주문 물리적 삭제 요청 - Order ID: {}, 요청자 ID: {}, 요청자 Role: {}", orderId, adminId, role);
+
+        // ADMIN, SUPER_ADMIN 권한 확인
+        if (role != Role.ADMIN && role != Role.SUPER_ADMIN) {
+            log.error("권한 부족 - Role: {}", role);
+            throw new BadRequestException(ErrorStatus.INVALID_ROLE_EXCEPTION.getMessage());
+        }
+
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> {
+                    log.error("주문을 찾을 수 없음 - Order ID: {}", orderId);
+                    return new NotFoundException(ErrorStatus.ORDER_NOT_FOUND_EXCEPTION.getMessage());
+                });
+
+        orderRepository.delete(order);
+
+        log.info("주문 물리적 삭제 완료 - Order ID: {}, Order Number: {}, 관리자 ID: {}, 관리자 Role: {}",
+                orderId, order.getOrderNumber(), adminId, role);
     }
 }

--- a/src/main/java/com/stockmate/order/common/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/stockmate/order/common/config/swagger/SwaggerConfig.java
@@ -36,9 +36,14 @@ public class SwaggerConfig {
         SecurityRequirement accessTokenRequirement = new SecurityRequirement().addList(accessTokenHeader);
         SecurityRequirement refreshTokenRequirement = new SecurityRequirement().addList(refreshTokenHeader);
 
-        Server server = new Server();
-        //server.setUrl("http://localhost:8001");
-        server.setUrl("https://api.stockmate.site");
+        // 여러 서버 URL 설정
+        Server productionServer = new Server();
+        productionServer.setUrl("https://api.stockmate.site");
+        productionServer.setDescription("운영 서버");
+
+        Server localServer = new Server();
+        localServer.setUrl("http://localhost:8003");
+        localServer.setDescription("로컬 서버");
 
         return new OpenAPI()
                 .info(new Info()
@@ -48,7 +53,8 @@ public class SwaggerConfig {
                 .components(new Components()
                         .addSecuritySchemes(accessTokenHeader, accessTokenScheme)
                         .addSecuritySchemes(refreshTokenHeader, refreshTokenScheme))
-                .addServersItem(server)
+                .addServersItem(productionServer)
+                .addServersItem(localServer)
                 .addSecurityItem(accessTokenRequirement)
                 .addSecurityItem(refreshTokenRequirement);
     }

--- a/src/main/java/com/stockmate/order/common/response/ErrorStatus.java
+++ b/src/main/java/com/stockmate/order/common/response/ErrorStatus.java
@@ -16,6 +16,8 @@ public enum ErrorStatus {
     USER_ALREADY_EXISTS_EXCEPTION(HttpStatus.BAD_REQUEST,"이미 존재하는 사용자입니다."),
     INVALID_ROLE_EXCEPTION(HttpStatus.BAD_REQUEST,"해당 요청을 수행할 권한이 없습니다."),
     SOLD_OUT_PARTS_EXCEPTION(HttpStatus.BAD_REQUEST,"부품 재고가 부족합니다."),
+    ALREADY_CANCELLED_ORDER_EXCEPTION(HttpStatus.BAD_REQUEST,"이미 취소된 주문입니다."),
+    ALREADY_SHIPPED_OR_DELIVERED_ORDER_EXCEPTION(HttpStatus.BAD_REQUEST,"배송 중이거나 완료된 주문은 취소할 수 없습니다."),
 
     /**
      * 401 UNAUTHORIZED
@@ -25,6 +27,7 @@ public enum ErrorStatus {
      * 404 NOT_FOUND
      */
     USER_NOTFOUND_EXCEPTION(HttpStatus.NOT_FOUND,"해당 사용자를 찾을 수 없습니다."),
+    ORDER_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND,"해당 주문을 찾을 수 없습니다."),
 
     /**
      * 500 SERVER_ERROR

--- a/src/main/java/com/stockmate/order/common/response/SuccessStatus.java
+++ b/src/main/java/com/stockmate/order/common/response/SuccessStatus.java
@@ -13,11 +13,13 @@ public enum SuccessStatus {
      * 200
      */
     SEND_HEALTH_CHECK_SUCCESS(HttpStatus.OK,"서버 상태 체크 성공"),
-    SEND_PARTS_ORDER_SUCCESS(HttpStatus.OK,"부품 주문 성공"),
+    SEND_CANCELLED_ORDER_SUCCESS(HttpStatus.OK, "주문 취소 성공"),
+    DELETE_ORDER_SUCCESS(HttpStatus.OK, "주문 삭제 성공"),
 
     /**
      * 201
      */
+    SEND_PARTS_ORDER_SUCCESS(HttpStatus.CREATED,"부품 주문 성공"),
 
     ;
 


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #18

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 주문 취소 기능을 구현하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신규 기능
  * 주문 취소 및 삭제 API 추가. 권한에 따라 취소/삭제 가능.
  * 주문 상태에 ‘취소됨’ 추가.
* 변경 사항
  * 부품 주문 성공 응답 코드가 200에서 201(생성)으로 변경.
  * 취소/삭제 성공 응답 메시지 추가.
* 개선
  * 취소/삭제 시 상세 오류 안내(이미 취소, 배송 진행/완료, 미존재 주문 등).
* 문서화
  * Swagger에 운영/로컬 서버 주소 동시 표시로 API 탐색 편의성 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->