### PR TITLE
[REFAC] 써킷 브레이커 등록

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,9 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+    // Circuit Breaker (Resilience4j)
+    implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-reactor-resilience4j'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/com/stockmate/order/api/order/service/fallback/InventoryServiceFallback.java
+++ b/src/main/java/com/stockmate/order/api/order/service/fallback/InventoryServiceFallback.java
@@ -1,0 +1,35 @@
+package com.stockmate.order.api.order.service.fallback;
+
+import com.stockmate.order.api.order.dto.InventoryCheckResponseDTO;
+import com.stockmate.order.api.order.dto.OrderItemCheckRequestDTO;
+import com.stockmate.order.api.order.dto.PartDetailResponseDTO;
+import com.stockmate.order.common.exception.InternalServerException;
+import com.stockmate.order.common.response.ErrorStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+@Slf4j
+public class InventoryServiceFallback {
+
+    /**
+     * 부품 재고 체크 Fallback
+     * - 주문 생성 시 필수이므로 예외를 발생시킴
+     */
+    public InventoryCheckResponseDTO checkInventoryFallback(List<OrderItemCheckRequestDTO> orderItems, Exception e) {
+        log.error("부품 재고 체크 Circuit Breaker 작동 - Fallback 실행. Error: {}", e.getMessage());
+        throw new InternalServerException(ErrorStatus.PARTS_SERVER_UNAVAILABLE_EXCEPTION.getMessage());
+    }
+
+    /**
+     * 부품 상세 정보 조회 Fallback
+     * - 주문 리스트 조회 시 부품 정보가 없으면 예외 발생
+     */
+    public Map<Long, PartDetailResponseDTO> getPartDetailsFallback(List<Long> partIds, Exception e) {
+        log.error("부품 상세 정보 조회 Circuit Breaker 작동 - Fallback 실행. Error: {}", e.getMessage());
+        throw new InternalServerException(ErrorStatus.PARTS_SERVER_UNAVAILABLE_EXCEPTION.getMessage());
+    }
+}

--- a/src/main/java/com/stockmate/order/api/order/service/fallback/UserServiceFallback.java
+++ b/src/main/java/com/stockmate/order/api/order/service/fallback/UserServiceFallback.java
@@ -1,0 +1,24 @@
+package com.stockmate.order.api.order.service.fallback;
+
+import com.stockmate.order.api.order.dto.UserBatchResponseDTO;
+import com.stockmate.order.common.exception.InternalServerException;
+import com.stockmate.order.common.response.ErrorStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+@Slf4j
+public class UserServiceFallback {
+
+    /**
+     * 사용자 정보 조회 Fallback
+     * - 주문 리스트 조회 시 사용자 정보가 없으면 예외 발생
+     */
+    public Map<Long, UserBatchResponseDTO> getUsersByMemberIdsFallback(List<Long> memberIds, Exception e) {
+        log.error("사용자 정보 조회 Circuit Breaker 작동 - Fallback 실행. Error: {}", e.getMessage());
+        throw new InternalServerException(ErrorStatus.USER_SERVER_UNAVAILABLE_EXCEPTION.getMessage());
+    }
+}

--- a/src/main/java/com/stockmate/order/common/response/ErrorStatus.java
+++ b/src/main/java/com/stockmate/order/common/response/ErrorStatus.java
@@ -18,6 +18,8 @@ public enum ErrorStatus {
     SOLD_OUT_PARTS_EXCEPTION(HttpStatus.BAD_REQUEST,"부품 재고가 부족합니다."),
     ALREADY_CANCELLED_ORDER_EXCEPTION(HttpStatus.BAD_REQUEST,"이미 취소된 주문입니다."),
     ALREADY_SHIPPED_OR_DELIVERED_ORDER_EXCEPTION(HttpStatus.BAD_REQUEST,"배송 중이거나 완료된 주문은 취소할 수 없습니다."),
+    PARTS_SERVER_UNAVAILABLE_EXCEPTION(HttpStatus.SERVICE_UNAVAILABLE,"부품 서버가 일시적으로 응답하지 않습니다. 잠시 후 다시 시도해주세요."),
+    USER_SERVER_UNAVAILABLE_EXCEPTION(HttpStatus.SERVICE_UNAVAILABLE,"사용자 서버가 일시적으로 응답하지 않습니다. 잠시 후 다시 시도해주세요."),
 
     /**
      * 401 UNAUTHORIZED


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #25

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 써킷 브레이커를 등록하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 외부 서비스 장애 시 자동 폴백이 적용되어 재고 확인, 부품 상세 조회, 사용자 정보 조회의 안정성이 향상되었습니다.
  - 서비스 일시 중단 시 일관된 503 응답과 안내 메시지가 제공됩니다.

- 개선
  - 오류 메시지를 명확화하여 “부품/사용자 서버가 일시적으로 응답하지 않습니다. 잠시 후 다시 시도해주세요.”를 표시합니다.

- 작업
  - 웹플럭스 스택에 회로 차단기용 리질리언스 의존성을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->