### PR TITLE
[FEAT] 시간대별 입출고 추이 조회 기능 구현

### DIFF
--- a/src/main/java/com/stockmate/order/api/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/stockmate/order/api/dashboard/controller/DashboardController.java
@@ -1,5 +1,6 @@
 package com.stockmate.order.api.dashboard.controller;
 
+import com.stockmate.order.api.dashboard.dto.HourlyInOutResponseDTO;
 import com.stockmate.order.api.dashboard.dto.TodayDashboardResponseDTO;
 import com.stockmate.order.api.dashboard.service.DashboardService;
 import com.stockmate.order.common.response.ApiResponse;
@@ -21,24 +22,36 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Dashboard", description = "대시보드 관련 API 입니다.")
 public class DashboardController {
 
-    private final DashboardService dashboardService;
+	private final DashboardService dashboardService;
 
-    @Operation(
-            summary = "금일 대시보드 조회",
-            description = "금일 주문 수, 배송 처리 수, 배송 중인 수, 매출 금액 및 시간대별 추이를 조회합니다."
-    )
-    @GetMapping("/today")
-    @PreAuthorize("hasAnyRole('ADMIN', 'SUPER_ADMIN')")
-    public ResponseEntity<ApiResponse<TodayDashboardResponseDTO>> getTodayDashboard() {
-        log.info("금일 대시보드 조회 요청");
+	@Operation(
+			summary = "금일 대시보드 조회",
+			description = "금일 주문 수, 배송 처리 수, 배송 중인 수, 매출 금액 및 시간대별 추이를 조회합니다."
+	)
+	@GetMapping("/today")
+	@PreAuthorize("hasAnyRole('ADMIN', 'SUPER_ADMIN')")
+	public ResponseEntity<ApiResponse<TodayDashboardResponseDTO>> getTodayDashboard() {
+		log.info("금일 대시보드 조회 요청");
 
-        TodayDashboardResponseDTO response = dashboardService.getTodayDashboard();
+		TodayDashboardResponseDTO response = dashboardService.getTodayDashboard();
 
-        log.info("금일 대시보드 조회 완료 - 총 주문: {}, 매출: {}", 
-                response.getSummary().getTotalOrders(), 
-                response.getSummary().getTotalRevenue());
+		log.info("금일 대시보드 조회 완료 - 총 주문: {}, 매출: {}",
+				response.getSummary().getTotalOrders(),
+				response.getSummary().getTotalRevenue());
 
-        return ApiResponse.success(SuccessStatus.GET_TODAY_DASHBOARD_SUCCESS, response);
-    }
+		return ApiResponse.success(SuccessStatus.GET_TODAY_DASHBOARD_SUCCESS, response);
+	}
+
+	@Operation(
+			summary = "금일 시간대별 입출고 추이",
+			description = "금일 0~23시 시간대별로 입고(주문) 수, 출고(배송 처리) 수를 조회합니다."
+	)
+	@GetMapping("/today/inout")
+	@PreAuthorize("hasAnyRole('ADMIN', 'SUPER_ADMIN')")
+	public ResponseEntity<ApiResponse<HourlyInOutResponseDTO>> getTodayInboundOutbound() {
+
+        var response = dashboardService.getTodayInboundOutbound();
+		return ApiResponse.success(SuccessStatus.GET_TODAY_INOUT_DASHBOARD_SUCCESS, response);
+	}
 }
 

--- a/src/main/java/com/stockmate/order/api/dashboard/dto/HourlyInOutResponseDTO.java
+++ b/src/main/java/com/stockmate/order/api/dashboard/dto/HourlyInOutResponseDTO.java
@@ -1,0 +1,26 @@
+package com.stockmate.order.api.dashboard.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class HourlyInOutResponseDTO {
+	private List<HourStat> hours; // 0~23
+
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Builder
+	public static class HourStat {
+		private int hour;              // 0-23
+		private long inboundOrders;    // 해당 시간대 생성된 주문 수
+		private long outboundShipped;  // 해당 시간대 배송 처리 수
+	}
+}

--- a/src/main/java/com/stockmate/order/common/response/SuccessStatus.java
+++ b/src/main/java/com/stockmate/order/common/response/SuccessStatus.java
@@ -9,38 +9,39 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public enum SuccessStatus {
 
-    /**
-     * 200
-     */
-    SEND_HEALTH_CHECK_SUCCESS(HttpStatus.OK,"서버 상태 체크 성공"),
-    SEND_ORDER_APPROVAL_REQUEST_SUCCESS(HttpStatus.OK, "주문 승인 요청 성공"),
-    CHECK_ORDER_APPROVAL_STATUS_SUCCESS(HttpStatus.OK, "주문 상태 조회 성공"),
-    SEND_CANCELLED_ORDER_SUCCESS(HttpStatus.OK, "주문 취소 성공"),
-    DELETE_ORDER_SUCCESS(HttpStatus.OK, "주문 삭제 성공"),
-    SEND_MY_ORDER_LIST_SUCCESS(HttpStatus.OK, "내 주문 리스트 조회 성공"),
-    SEND_ORDER_LIST_SUCCESS(HttpStatus.OK, "주문 리스트 조회 성공"),
-    SEND_ORDER_DETAIL_SUCCESS(HttpStatus.OK, "주문 상세 조회 성공"),
-    SEND_ORDER_REJECT_REQUEST_SUCCESS(HttpStatus.OK,"주문 반려 성공"),
-    SEND_CART_MODIFY_SUCCESS(HttpStatus.OK,"장바구니 수정 성공"),
-    SEND_CART_DELETE_SUCCESS(HttpStatus.OK,"장바구니 삭제 성공"),
-    SEND_CART_DATA_SUCCESS(HttpStatus.OK,"장바구니 조회 성공"),
-    REGISTER_SHIPPING_SUCCESS(HttpStatus.OK,"배송 등록 성공"),
-    REQUEST_RECEIVING_PROCESS_SUCCESS(HttpStatus.OK,"입고 처리 요청 성공"),
-    CHECK_ORDER_DATA_SUCCESS(HttpStatus.OK, "주문 검증 조회 성공"),
-    GET_TODAY_DASHBOARD_SUCCESS(HttpStatus.OK, "금일 대시보드 조회 성공"),
+	/**
+	 * 200
+	 */
+	SEND_HEALTH_CHECK_SUCCESS(HttpStatus.OK,"서버 상태 체크 성공"),
+	SEND_ORDER_APPROVAL_REQUEST_SUCCESS(HttpStatus.OK, "주문 승인 요청 성공"),
+	CHECK_ORDER_APPROVAL_STATUS_SUCCESS(HttpStatus.OK, "주문 상태 조회 성공"),
+	SEND_CANCELLED_ORDER_SUCCESS(HttpStatus.OK, "주문 취소 성공"),
+	DELETE_ORDER_SUCCESS(HttpStatus.OK, "주문 삭제 성공"),
+	SEND_MY_ORDER_LIST_SUCCESS(HttpStatus.OK, "내 주문 리스트 조회 성공"),
+	SEND_ORDER_LIST_SUCCESS(HttpStatus.OK, "주문 리스트 조회 성공"),
+	SEND_ORDER_DETAIL_SUCCESS(HttpStatus.OK, "주문 상세 조회 성공"),
+	SEND_ORDER_REJECT_REQUEST_SUCCESS(HttpStatus.OK,"주문 반려 성공"),
+	SEND_CART_MODIFY_SUCCESS(HttpStatus.OK,"장바구니 수정 성공"),
+	SEND_CART_DELETE_SUCCESS(HttpStatus.OK,"장바구니 삭제 성공"),
+	SEND_CART_DATA_SUCCESS(HttpStatus.OK,"장바구니 조회 성공"),
+	REGISTER_SHIPPING_SUCCESS(HttpStatus.OK,"배송 등록 성공"),
+	REQUEST_RECEIVING_PROCESS_SUCCESS(HttpStatus.OK,"입고 처리 요청 성공"),
+	CHECK_ORDER_DATA_SUCCESS(HttpStatus.OK, "주문 검증 조회 성공"),
+	GET_TODAY_DASHBOARD_SUCCESS(HttpStatus.OK, "금일 대시보드 조회 성공"),
+	GET_TODAY_INOUT_DASHBOARD_SUCCESS(HttpStatus.OK, "금일 시간대별 입출고 조회 성공"),
 
-    /**
-     * 201
-     */
-    SEND_PARTS_ORDER_SUCCESS(HttpStatus.CREATED,"부품 주문 성공"),
-    SEND_CART_CREATE_SUCCESS(HttpStatus.CREATED, "장바구니 생성 성공"),
+	/**
+	 * 201
+	 */
+	SEND_PARTS_ORDER_SUCCESS(HttpStatus.CREATED,"부품 주문 성공"),
+	SEND_CART_CREATE_SUCCESS(HttpStatus.CREATED, "장바구니 생성 성공"),
 
-    ;
+	;
 
-    private final HttpStatus httpStatus;
-    private final String message;
+	private final HttpStatus httpStatus;
+	private final String message;
 
-    public int getStatusCode() {
-        return this.httpStatus.value();
-    }
+	public int getStatusCode() {
+		return this.httpStatus.value();
+	}
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #113

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 시간대별 입출고 추이 조회 기능을 구현하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **New Features**
  * 시간별 입출고 현황을 조회할 수 있는 새로운 대시보드 API 엔드포인트 추가
  * 당일 0~23시 시간대별 입고 주문 수와 출고 건수 실시간 조회 가능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->