### PR TITLE
[FEAT] 대시보드 집계 상태값 체크 수정

### DIFF
--- a/src/main/java/com/stockmate/order/api/order/repository/OrderRepository.java
+++ b/src/main/java/com/stockmate/order/api/order/repository/OrderRepository.java
@@ -27,8 +27,8 @@ public interface OrderRepository extends JpaRepository<Order, Long>, OrderReposi
     @Query("SELECT o FROM Order o LEFT JOIN FETCH o.orderItems WHERE o.orderNumber = :orderNumber")
     Optional<Order> findByOrderNumberWithItems(@Param("orderNumber") String orderNumber);
     
-    // 대시보드: 금일 주문 수
-    @Query("SELECT COUNT(o) FROM Order o WHERE o.createdAt >= :startOfDay AND o.createdAt < :endOfDay")
+    // 대시보드: 금일 주문 수 (PAY_COMPLETED 상태만 집계)
+    @Query("SELECT COUNT(o) FROM Order o WHERE o.orderStatus = 'PAY_COMPLETED' AND o.createdAt >= :startOfDay AND o.createdAt < :endOfDay")
     long countTodayOrders(@Param("startOfDay") LocalDateTime startOfDay, @Param("endOfDay") LocalDateTime endOfDay);
     
     // 대시보드: 금일 배송 처리된 수 (SHIPPING 상태로 변경된 수)
@@ -43,8 +43,8 @@ public interface OrderRepository extends JpaRepository<Order, Long>, OrderReposi
     @Query("SELECT COALESCE(SUM(o.totalPrice), 0) FROM Order o WHERE o.orderStatus = 'PAY_COMPLETED' AND o.createdAt >= :startOfDay AND o.createdAt < :endOfDay")
     long calculateTodayRevenue(@Param("startOfDay") LocalDateTime startOfDay, @Param("endOfDay") LocalDateTime endOfDay);
     
-    // 대시보드: 시간대별 주문 수
-    @Query("SELECT HOUR(o.createdAt), COUNT(o) FROM Order o WHERE o.createdAt >= :startOfDay AND o.createdAt < :endOfDay GROUP BY HOUR(o.createdAt) ORDER BY HOUR(o.createdAt)")
+    // 대시보드: 시간대별 주문 수 (PAY_COMPLETED 상태만 집계)
+    @Query("SELECT HOUR(o.createdAt), COUNT(o) FROM Order o WHERE o.orderStatus = 'PAY_COMPLETED' AND o.createdAt >= :startOfDay AND o.createdAt < :endOfDay GROUP BY HOUR(o.createdAt) ORDER BY HOUR(o.createdAt)")
     List<Object[]> countOrdersByHour(@Param("startOfDay") LocalDateTime startOfDay, @Param("endOfDay") LocalDateTime endOfDay);
     
     // 대시보드: 시간대별 배송 처리 수


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #122

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 대시보드 집계 상태값 체크를 수정하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 대시보드의 일일 주문 건수 및 시간별 주문 건수 쿼리가 개선되었습니다
* 대시보드 집계가 이제 결제 완료 상태의 주문만 포함하도록 필터링됩니다

<!-- end of auto-generated comment: release notes by coderabbit.ai -->